### PR TITLE
Add a way to get all property keys from the Properties struct.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,12 @@ impl From<HashMap<String, String>> for Properties {
     }
 }
 
+impl From<Properties> for HashMap<String, String> {
+    fn from(value: Properties) -> Self {
+        value.0
+    }
+}
+
 impl Properties {
     /// Gets the corresponding value for a property key.
     pub fn get_property<'a>(&self, key: &'a str) -> Result<&'_ str, PropertyNotFoundError<'a>> {
@@ -35,6 +41,11 @@ impl Properties {
     /// Sets a value for a property key.
     pub fn set_property(&mut self, key: String, value: String) -> Option<String> {
         self.0.insert(key, value)
+    }
+
+    /// Returns an iterator over all keys in the Properties map.
+    pub fn keys(&self) -> impl Iterator<Item = &String> {
+        self.0.keys()
     }
 
     pub fn write_without_spaces<W: Write>(&self, writer: &mut W) -> Result<(), io::Error> {


### PR DESCRIPTION
Currently there is no way to get all property keys from your property implementation.

Why do I need this?
I want load java resource bundles and generate rust code in a proc-macro from them.
Each element in the resource bundle would result in a generated constant in the rust code.
Doing so without getting the list of keys is not possible.

Also:
I added a "From<Properties> for HashMap<String,String>" impl because for some people just getting the HashMap once
the property file is parsed is preferable.

Once (and If...) this is merged, I would appreciate it if you could make a new release.